### PR TITLE
[IDP-3137] Automatically create stable releases from latest commits

### DIFF
--- a/.github/create-stable-release.yml
+++ b/.github/create-stable-release.yml
@@ -1,0 +1,15 @@
+name: Create stable release
+
+on:
+  schedule:
+    - cron: "0 3 * * 0" # At 03:00 on Sunday
+  workflow_dispatch:
+
+jobs:
+  create-release:
+    permissions:
+      contents: write
+    uses: workleap/wl-reusable-workflows/.github/workflows/create-stable-release.yml
+    secrets:
+      # HACK I'm using this token temporarily to test the workflow
+      token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/create-stable-release.yml
+++ b/.github/create-stable-release.yml
@@ -11,5 +11,5 @@ jobs:
       contents: write
     uses: workleap/wl-reusable-workflows/.github/workflows/create-stable-release.yml
     secrets:
-      # HACK I'm using this token temporarily to test the workflow
+      # TODO Temporarily using this token as it is supposed to have the required permissions
       token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
This is the first attempt to use [the new reusable workflow](https://github.com/workleap/wl-reusable-workflows/blob/main/.github/workflows/create-stable-release.yml) to automatically create releases when there have been commits since the last stable release.

The workflow requires a token with `contents: write` permissions. Before asking IT, I wanted to test it with an existing token (if it has the correct permissions) and later on ask for a dedicated org token and use it across all our repos for this use case.