### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,3 +47,4 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
+      cortexEntityIdOrTag: service-wl-extensions-configuration-substitution


### PR DESCRIPTION
Jira issue link: [feng-722](https://workleap.atlassian.net/browse/feng-722)

This pull request updates the GitHub Actions workflow to include a new configuration parameter for deployment.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R50): Added the `cortexEntityIdOrTag` parameter with the value `service-wl-extensions-configuration-substitution` to the `linearb-deployment.yml` reusable workflow. This ensures the correct Cortex entity or tag is used during the deployment process.